### PR TITLE
Remove the requirement of GNU strip

### DIFF
--- a/repack-mysql.sh
+++ b/repack-mysql.sh
@@ -22,13 +22,6 @@ fi
 STRIP=strip
 command -v gstrip >/dev/null && STRIP=gstrip
 
-if ! $STRIP --version | grep -q "GNU strip"
-then
-    echo "GNU strip is required."
-    echo "Hint: brew install binutils"
-    exit 100
-fi
-
 set -x
 
 cd $(dirname $0)


### PR DESCRIPTION
On OSX, the command would fail becaus GNU strip is not available,
and OSX strip does not support --version.