### PR TITLE
Add support for ppc64le centos7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,11 @@ language: java
 jdk: 
  - openjdk8
 
+addon:
+ apt:
+  packages:
+   - rpm2cpio
+   - cpio
+
 install: true
 script: mvn verify

--- a/testing-mysql-server-5/repack-mysql-5.sh
+++ b/testing-mysql-server-5/repack-mysql-5.sh
@@ -4,8 +4,10 @@ set -eu
 
 VERSION=5.7.22
 BASEURL="https://dev.mysql.com/get/Downloads/MySQL-5.7"
+PPC64LE_BASEURL="http://yum.mariadb.org/10.2/centos/7/ppc64le/rpms/"
 
 LINUX_BASE=mysql-$VERSION-linux-glibc2.12-x86_64
+LINUX_PPC64LE_RPM=MariaDB-server-10.2.32-1.el7.centos.ppc64le.rpm
 OSX_BASE=mysql-$VERSION-macos10.13-x86_64
 
 TAR=tar
@@ -40,10 +42,13 @@ mkdir -p dist $RESOURCES
 LINUX_NAME=$LINUX_BASE.tar.gz
 LINUX_DIST=dist/$LINUX_NAME
 
+LINUX_PPC64LE_DIST=dist/$LINUX_PPC64LE_RPM
+
 OSX_NAME=$OSX_BASE.tar.gz
 OSX_DIST=dist/$OSX_NAME
 
 test -e $LINUX_DIST || curl -L -o $LINUX_DIST "$BASEURL/$LINUX_NAME"
+test -e $LINUX_PPC64LE_DIST || curl -L -o $LINUX_PPC64LE_DIST "$PPC64LE_BASEURL/$LINUX_PPC64LE_RPM"
 test -e $OSX_DIST || curl -L -o $OSX_DIST "$BASEURL/$OSX_NAME"
 
 PACKDIR=$(mktemp -d "${TMPDIR:-/tmp}/mysql.XXXXXXXXXX")
@@ -59,6 +64,21 @@ $TAR -czf $OLDPWD/$RESOURCES/mysql-Linux-amd64.tar.gz \
   share/charsets \
   share/english \
   bin/mysqld
+popd
+rm -rf $PACKDIR
+
+PACKDIR=$(mktemp -d "${TMPDIR:-/tmp}/mysql.XXXXXXXXXX")
+cp $LINUX_PPC64LE_DIST $PACKDIR/
+pushd $PACKDIR
+rpm2cpio $LINUX_PPC64LE_RPM | cpio -idm
+mkdir -p mysql-Linux-ppc64le/bin mysql-Linux-ppc64le/lib64 mysql-Linux-ppc64le/share mysql-Linux-ppc64le/data
+cp usr/bin/mysql_install_db mysql-Linux-ppc64le/bin/
+cp usr/bin/my_print_defaults mysql-Linux-ppc64le/bin/
+cp usr/bin/resolveip mysql-Linux-ppc64le/bin/
+cp usr/sbin/mysqld mysql-Linux-ppc64le/bin/
+cp -r usr/lib64/* mysql-Linux-ppc64le/lib64/
+cp -r usr/share/mysql mysql-Linux-ppc64le/share/
+$TAR -C ./mysql-Linux-ppc64le -czf $OLDPWD/$RESOURCES/mysql-Linux-ppc64le.tar.gz bin lib64 share data
 popd
 rm -rf $PACKDIR
 

--- a/testing-mysql-server-5/src/main/java/com/facebook/presto/testing/mysql/EmbeddedMySql5.java
+++ b/testing-mysql-server-5/src/main/java/com/facebook/presto/testing/mysql/EmbeddedMySql5.java
@@ -13,11 +13,9 @@
  */
 package com.facebook.presto.testing.mysql;
 
-import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableList;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 
 final class EmbeddedMySql5
@@ -32,48 +30,54 @@ final class EmbeddedMySql5
     @Override
     public List<String> getInitializationArguments()
     {
-        List<String> list = Arrays.asList(
-                "--no-defaults",
-                "--skip-sync-frm",
-                "--innodb-flush-method=nosync",
-                "--datadir=" + getDataDirectory());
+        ImmutableList.Builder<String> iList = ImmutableList.<String>builder()
+                .add(
+                    "--no-defaults",
+                    "--skip-sync-frm",
+                    "--innodb-flush-method=nosync",
+                    "--datadir=" + getDataDirectory());
 
         if (isMariadb) {
-            return ImmutableList.<String>builder().addAll(list).add("--basedir=" + getBaseDirectory()).build();
+            return iList.add("--basedir=" + getBaseDirectory()).build();
         }
         else {
-            return ImmutableList.<String>builder().addAll(list).add("--initialize-insecure").build();
+            return iList.add("--initialize-insecure").build();
         }
     }
 
     @Override
-    public List<String> getStartArguments() throws VerifyException
+    public List<String> getStartArguments()
     {
-        List<String> list = Arrays.asList(
-                "--no-defaults",
-                "--default-time-zone=+00:00",
-                "--skip-sync-frm",
-                "--innodb-flush-method=nosync",
-                "--innodb-flush-log-at-trx-commit=0",
-                "--innodb-doublewrite=0",
-                "--bind-address=localhost",
-                "--port=" + String.valueOf(getPort()),
-                "--datadir=" + getDataDirectory(),
-                "--socket=" + getSocketDirectory());
+        ImmutableList.Builder<String> iList = ImmutableList.<String>builder()
+                .add(
+                    "--no-defaults",
+                    "--default-time-zone=+00:00",
+                    "--skip-sync-frm",
+                    "--innodb-flush-method=nosync",
+                    "--innodb-flush-log-at-trx-commit=0",
+                    "--innodb-doublewrite=0",
+                    "--bind-address=localhost",
+                    "--port=" + String.valueOf(getPort()),
+                    "--datadir=" + getDataDirectory(),
+                    "--socket=" + getSocketDirectory());
 
         if (isMariadb) {
-            return ImmutableList.<String>builder().addAll(list).add(
-                "--basedir=" + getBaseDirectory(),
-                "--plugin-dir=" + getMariadbPluginDirectory(),
-                "--log-error=" + getDataDirectory() + "mariadb.log",
-                "--pid-file=" + getDataDirectory() + "mariadb.pid").build();
+            return iList
+                .add(
+                    "--basedir=" + getBaseDirectory(),
+                    "--plugin-dir=" + getMariadbPluginDirectory(),
+                    "--log-error=" + getDataDirectory() + "mariadb.log",
+                    "--pid-file=" + getDataDirectory() + "mariadb.pid")
+                .build();
         }
         else {
-            return ImmutableList.<String>builder().addAll(list).add(
-                "--skip-ssl",
-                "--disable-partition-engine-check",
-                "--explicit_defaults_for_timestamp",
-                "--lc_messages_dir=" + getShareDirectory()).build();
+            return iList
+                .add(
+                    "--skip-ssl",
+                    "--disable-partition-engine-check",
+                    "--explicit_defaults_for_timestamp",
+                    "--lc_messages_dir=" + getShareDirectory())
+                .build();
         }
     }
 }

--- a/testing-mysql-server-5/src/main/java/com/facebook/presto/testing/mysql/EmbeddedMySql5.java
+++ b/testing-mysql-server-5/src/main/java/com/facebook/presto/testing/mysql/EmbeddedMySql5.java
@@ -13,9 +13,11 @@
  */
 package com.facebook.presto.testing.mysql;
 
+import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableList;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 
 final class EmbeddedMySql5
@@ -30,60 +32,48 @@ final class EmbeddedMySql5
     @Override
     public List<String> getInitializationArguments()
     {
-        if (isMariadb) {
-            return ImmutableList.of(
+        List<String> list = Arrays.asList(
                 "--no-defaults",
-                "--basedir=" + getBaseDirectory(),
-                "--datadir=" + getDataDirectory(),
                 "--skip-sync-frm",
-                "--innodb-flush-method=nosync");
+                "--innodb-flush-method=nosync",
+                "--datadir=" + getDataDirectory());
+
+        if (isMariadb) {
+            return ImmutableList.<String>builder().addAll(list).add("--basedir=" + getBaseDirectory()).build();
         }
         else {
-            return ImmutableList.of(
-                    "--no-defaults",
-                    "--initialize-insecure",
-                    "--skip-sync-frm",
-                    "--innodb-flush-method=nosync",
-                    "--datadir", getDataDirectory());
+            return ImmutableList.<String>builder().addAll(list).add("--initialize-insecure").build();
         }
     }
 
     @Override
-    public List<String> getStartArguments()
+    public List<String> getStartArguments() throws VerifyException
     {
+        List<String> list = Arrays.asList(
+                "--no-defaults",
+                "--default-time-zone=+00:00",
+                "--skip-sync-frm",
+                "--innodb-flush-method=nosync",
+                "--innodb-flush-log-at-trx-commit=0",
+                "--innodb-doublewrite=0",
+                "--bind-address=localhost",
+                "--port=" + String.valueOf(getPort()),
+                "--datadir=" + getDataDirectory(),
+                "--socket=" + getSocketDirectory());
+
         if (isMariadb) {
-            return ImmutableList.of(
-                    "--no-defaults",
-                    "--default-time-zone=+00:00",
-                    "--skip-sync-frm",
-                    "--innodb-flush-method=nosync",
-                    "--innodb-flush-log-at-trx-commit=0",
-                    "--innodb-doublewrite=0",
-                    "--bind-address=localhost",
-                    "--basedir=" + getBaseDirectory(),
-                    "--plugin-dir=" + getPluginDirectory(),
-                    "--log-error=" + getDataDirectory() + "mariadb.log",
-                    "--pid-file=" + getDataDirectory() + "mariadb.pid",
-                    "--socket=" + getDataDirectory() + "mysql.sock",
-                    "--port=" + String.valueOf(getPort()),
-                    "--datadir=" + getDataDirectory());
+            return ImmutableList.<String>builder().addAll(list).add(
+                "--basedir=" + getBaseDirectory(),
+                "--plugin-dir=" + getMariadbPluginDirectory(),
+                "--log-error=" + getDataDirectory() + "mariadb.log",
+                "--pid-file=" + getDataDirectory() + "mariadb.pid").build();
         }
         else {
-            return ImmutableList.of(
-                    "--no-defaults",
-                    "--skip-ssl",
-                    "--default-time-zone=+00:00",
-                    "--disable-partition-engine-check",
-                    "--explicit_defaults_for_timestamp",
-                    "--skip-sync-frm",
-                    "--innodb-flush-method=nosync",
-                    "--innodb-flush-log-at-trx-commit=0",
-                    "--innodb-doublewrite=0",
-                    "--bind-address=localhost",
-                    "--lc_messages_dir", getShareDirectory(),
-                    "--socket", getSocketDirectory(),
-                    "--port", String.valueOf(getPort()),
-                    "--datadir", getDataDirectory());
+            return ImmutableList.<String>builder().addAll(list).add(
+                "--skip-ssl",
+                "--disable-partition-engine-check",
+                "--explicit_defaults_for_timestamp",
+                "--lc_messages_dir=" + getShareDirectory()).build();
         }
     }
 }

--- a/testing-mysql-server-5/src/main/java/com/facebook/presto/testing/mysql/EmbeddedMySql5.java
+++ b/testing-mysql-server-5/src/main/java/com/facebook/presto/testing/mysql/EmbeddedMySql5.java
@@ -30,31 +30,60 @@ final class EmbeddedMySql5
     @Override
     public List<String> getInitializationArguments()
     {
-        return ImmutableList.of(
+        if (isMariadb) {
+            return ImmutableList.of(
                 "--no-defaults",
-                "--initialize-insecure",
+                "--basedir=" + getBaseDirectory(),
+                "--datadir=" + getDataDirectory(),
                 "--skip-sync-frm",
-                "--innodb-flush-method=nosync",
-                "--datadir", getDataDirectory());
+                "--innodb-flush-method=nosync");
+        }
+        else {
+            return ImmutableList.of(
+                    "--no-defaults",
+                    "--initialize-insecure",
+                    "--skip-sync-frm",
+                    "--innodb-flush-method=nosync",
+                    "--datadir", getDataDirectory());
+        }
     }
 
     @Override
     public List<String> getStartArguments()
     {
-        return ImmutableList.of(
-                "--no-defaults",
-                "--skip-ssl",
-                "--default-time-zone=+00:00",
-                "--disable-partition-engine-check",
-                "--explicit_defaults_for_timestamp",
-                "--skip-sync-frm",
-                "--innodb-flush-method=nosync",
-                "--innodb-flush-log-at-trx-commit=0",
-                "--innodb-doublewrite=0",
-                "--bind-address=localhost",
-                "--lc_messages_dir", getShareDirectory(),
-                "--socket", getSocketDirectory(),
-                "--port", String.valueOf(getPort()),
-                "--datadir", getDataDirectory());
+        if (isMariadb) {
+            return ImmutableList.of(
+                    "--no-defaults",
+                    "--default-time-zone=+00:00",
+                    "--skip-sync-frm",
+                    "--innodb-flush-method=nosync",
+                    "--innodb-flush-log-at-trx-commit=0",
+                    "--innodb-doublewrite=0",
+                    "--bind-address=localhost",
+                    "--basedir=" + getBaseDirectory(),
+                    "--plugin-dir=" + getPluginDirectory(),
+                    "--log-error=" + getDataDirectory() + "mariadb.log",
+                    "--pid-file=" + getDataDirectory() + "mariadb.pid",
+                    "--socket=" + getDataDirectory() + "mysql.sock",
+                    "--port=" + String.valueOf(getPort()),
+                    "--datadir=" + getDataDirectory());
+        }
+        else {
+            return ImmutableList.of(
+                    "--no-defaults",
+                    "--skip-ssl",
+                    "--default-time-zone=+00:00",
+                    "--disable-partition-engine-check",
+                    "--explicit_defaults_for_timestamp",
+                    "--skip-sync-frm",
+                    "--innodb-flush-method=nosync",
+                    "--innodb-flush-log-at-trx-commit=0",
+                    "--innodb-doublewrite=0",
+                    "--bind-address=localhost",
+                    "--lc_messages_dir", getShareDirectory(),
+                    "--socket", getSocketDirectory(),
+                    "--port", String.valueOf(getPort()),
+                    "--datadir", getDataDirectory());
+        }
     }
 }

--- a/testing-mysql-server-5/src/test/java/com/facebook/presto/testing/mysql/TestTestingMySqlServer.java
+++ b/testing-mysql-server-5/src/test/java/com/facebook/presto/testing/mysql/TestTestingMySqlServer.java
@@ -18,10 +18,13 @@ import static java.util.Arrays.asList;
 public class TestTestingMySqlServer
         extends AbstractTestTestingMySqlServer
 {
+    // for ppc64le, mariadb 10.2.x is used as an alternative for mysql 5.7
+    private static final boolean isMariadb = System.getProperty("os.arch").equals("ppc64le");
+
     @Override
     public String getMySqlVersion()
     {
-        return "5.7.22";
+        return (isMariadb ? "5.5.5-10.2.32-MariaDB" : "5.7.22");
     }
 
     @Override

--- a/testing-mysql-server-base/src/main/java/com/facebook/presto/testing/mysql/AbstractEmbeddedMySql.java
+++ b/testing-mysql-server-base/src/main/java/com/facebook/presto/testing/mysql/AbstractEmbeddedMySql.java
@@ -73,7 +73,7 @@ public abstract class AbstractEmbeddedMySql
     protected final boolean isMariadb = System.getProperty("os.arch").equals("ppc64le");
 
     public AbstractEmbeddedMySql(MySqlOptions mySqlOptions)
-            throws IOException, VerifyException
+            throws IOException
     {
         this.startupWait = requireNonNull(mySqlOptions.getStartupWait(), "startupWait is null");
         this.shutdownWait = requireNonNull(mySqlOptions.getShutdownWait(), "shutdownWait is null");
@@ -114,7 +114,7 @@ public abstract class AbstractEmbeddedMySql
         return DriverManager.getConnection(getJdbcUrl("root", "mysql"));
     }
 
-    protected String getMariadbInstallDb() throws VerifyException
+    protected String getMariadbInstallDb()
     {
         if (!isMariadb) {
             throw new VerifyException("mysql_install_db not applicable to non-mariadb installations");
@@ -147,7 +147,7 @@ public abstract class AbstractEmbeddedMySql
         return (isMariadb ? getDataDirectory() + "mysql.sock" : serverDirectory.resolve("mysql.sock").toString());
     }
 
-    protected String getMariadbPluginDirectory() throws VerifyException
+    protected String getMariadbPluginDirectory()
     {
         if (!isMariadb) {
             throw new VerifyException("--plugin-dir option not applicable to non-mariadb installations");
@@ -206,7 +206,7 @@ public abstract class AbstractEmbeddedMySql
         }
     }
 
-    private void initialize() throws VerifyException
+    private void initialize()
     {
         if (isMariadb) {
             system(ImmutableList.<String>builder()
@@ -223,7 +223,7 @@ public abstract class AbstractEmbeddedMySql
     }
 
     private Process startMysqld()
-            throws IOException, VerifyException
+            throws IOException
     {
         Process process = new ProcessBuilder(ImmutableList.<String>builder().add(getMysqld()).addAll(getStartArguments()).build())
                 .redirectErrorStream(true)

--- a/testing-mysql-server-base/src/main/java/com/facebook/presto/testing/mysql/AbstractTestingMySqlServer.java
+++ b/testing-mysql-server-base/src/main/java/com/facebook/presto/testing/mysql/AbstractTestingMySqlServer.java
@@ -31,6 +31,9 @@ public abstract class AbstractTestingMySqlServer
 {
     private static final Logger log = Logger.get(AbstractTestingMySqlServer.class);
 
+    // for ppc64le, mariadb 10.2.x is used as an alternative for mysql 5.7
+    private static final boolean isMariadb = System.getProperty("os.arch").equals("ppc64le");
+
     private final String user;
     private final String password;
     private final Set<String> databases;
@@ -50,8 +53,8 @@ public abstract class AbstractTestingMySqlServer
         try (Connection connection = server.getMySqlDatabase()) {
             version = connection.getMetaData().getDatabaseProductVersion();
             try (Statement statement = connection.createStatement()) {
-                execute(statement, format("CREATE USER '%s'@'%%' IDENTIFIED BY '%s'", user, password));
-                execute(statement, format("GRANT ALL ON *.* to '%s'@'%%' WITH GRANT OPTION", user));
+                execute(statement, format("CREATE USER '%s'@'%s' IDENTIFIED BY '%s'", user, isMariadb ? "localhost" : "%%", password));
+                execute(statement, format("GRANT ALL ON *.* to '%s'@'%s' WITH GRANT OPTION", user, isMariadb ? "localhost" : "%%"));
                 for (String database : databases) {
                     execute(statement, format("CREATE DATABASE %s", database));
                 }

--- a/testing-mysql-server-base/src/main/java/com/facebook/presto/testing/mysql/AbstractTestingMySqlServer.java
+++ b/testing-mysql-server-base/src/main/java/com/facebook/presto/testing/mysql/AbstractTestingMySqlServer.java
@@ -53,8 +53,8 @@ public abstract class AbstractTestingMySqlServer
         try (Connection connection = server.getMySqlDatabase()) {
             version = connection.getMetaData().getDatabaseProductVersion();
             try (Statement statement = connection.createStatement()) {
-                execute(statement, format("CREATE USER '%s'@'%s' IDENTIFIED BY '%s'", user, isMariadb ? "localhost" : "%%", password));
-                execute(statement, format("GRANT ALL ON *.* to '%s'@'%s' WITH GRANT OPTION", user, isMariadb ? "localhost" : "%%"));
+                execute(statement, format("CREATE USER '%s'@'localhost' IDENTIFIED BY '%s'", user, password));
+                execute(statement, format("GRANT ALL ON *.* to '%s'@'localhost' WITH GRANT OPTION", user));
                 for (String database : databases) {
                     execute(statement, format("CREATE DATABASE %s", database));
                 }


### PR DESCRIPTION
MariaDB 10.2.32 is used for ppc64le, since mysql does not have wide
support on ppc64le. On the other hand, mariadb, which is a drop in
replacement for mysql, has better support and availability on power.
The reason for chosing version 10.2.x is its' compatibility with
mysql 5.x.

Fixes https://github.com/prestodb/testing-mysql-server/issues/12