### PR TITLE
Patch libaio.so for testing-mysql-server-8

### DIFF
--- a/.github/workflows/testing-mysql-server-8.yml
+++ b/.github/workflows/testing-mysql-server-8.yml
@@ -1,0 +1,33 @@
+name: Java Maven Build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Install libaio-dev
+        run: |
+          sudo apt-get install -y libaio-dev
+      - name: Run Maven install
+        run: ./mvnw -B --no-transfer-progress clean install -pl testing-mysql-server-8 -am

--- a/testing-mysql-server-8/repack-mysql-8.sh
+++ b/testing-mysql-server-8/repack-mysql-8.sh
@@ -29,6 +29,9 @@ then
     exit 100
 fi
 
+PATCHELF=PATCHELF
+command -v patchelf >/dev/null && PATCHELF=patchelf
+
 set -x
 
 cd $(dirname $0)
@@ -83,6 +86,10 @@ function pack_linux() {
     $TAR -xf $1 -C $PACKDIR
     pushd $PACKDIR/$2
     $STRIP bin/mysqld
+    # on newer versions of ubuntu, libaio is replaced with libaiot64. Update the mysql
+    # binary to point to libaio.so which should exist on all systems when
+    # libaio-dev/devel are installed
+    $PATCHELF --replace-needed libaio.so.1 libaio.so bin/mysqld
     $TAR --dereference -czf $OLDPWD/$RESOURCES/$3 \
       LICENSE \
       README \

--- a/testing-mysql-server-8/src/main/java/com/facebook/presto/testing/mysql/EmbeddedMySql8.java
+++ b/testing-mysql-server-8/src/main/java/com/facebook/presto/testing/mysql/EmbeddedMySql8.java
@@ -42,7 +42,6 @@ final class EmbeddedMySql8
     {
         return ImmutableList.of(
                 "--no-defaults",
-                "--skip-ssl",
                 "--skip-mysqlx",
                 "--default-time-zone=+00:00",
                 "--innodb-flush-method=nosync",

--- a/testing-mysql-server-8/src/main/java/com/facebook/presto/testing/mysql/EmbeddedMySql8.java
+++ b/testing-mysql-server-8/src/main/java/com/facebook/presto/testing/mysql/EmbeddedMySql8.java
@@ -42,6 +42,7 @@ final class EmbeddedMySql8
     {
         return ImmutableList.of(
                 "--no-defaults",
+                "--user=" + System.getProperty("user.name"),
                 "--skip-mysqlx",
                 "--default-time-zone=+00:00",
                 "--innodb-flush-method=nosync",

--- a/testing-mysql-server-8/src/test/java/com/facebook/presto/testing/mysql/TestTestingMySqlServer.java
+++ b/testing-mysql-server-8/src/test/java/com/facebook/presto/testing/mysql/TestTestingMySqlServer.java
@@ -21,7 +21,7 @@ public class TestTestingMySqlServer
     @Override
     public String getMySqlVersion()
     {
-        return "8.0.15";
+        return "8.4.3";
     }
 
     @Override


### PR DESCRIPTION
PR to fix #26 

This repository no longer builds properly due to updated MySQL download URLs. The first two commits add CI and solve build issues. The final commit is the compatibility fix for ubuntu 24.

The fix is to patch the mysql binary to instead look for `libaio.so` over `libaio.so.1`. `libaio.so` is the standard unversioned name of the library that is included with the development headers of libaio.

This change will require linux environments which use this library to have the `libaio-dev[el]` package installed. It already requires `libnuma1` and `libaio1` previously, so I don't think it's too big of an ask.

The plan after this PR merges would be to update the dependency in prestodb from `testing-mysql-server-5` to `testing-mysql-server-8`. I think we should consider removing the `testing-mysql-server-5` module from this project since MySQL 5 is EOL at this point