### PR TITLE
Use Arm64 builds for macos support

### DIFF
--- a/.github/workflows/testing-mysql-server-8.yml
+++ b/.github/workflows/testing-mysql-server-8.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-14]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 
@@ -27,19 +27,24 @@ jobs:
           distribution: 'corretto'
           cache: 'maven'
       - name: Set up Homebrew
-        if: matrix.os == 'macos-14'
+        if: matrix.os == 'macos-latest'
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
       - name: Install GNU binutils
-        if: matrix.os == 'macos-14'
+        if: matrix.os == 'macos-latest'
         run: |
           brew install binutils
           brew install patchelf
           echo /opt/homebrew/opt/binutils/bin >> $GITHUB_PATH
       - name: Install libaio-dev
-        if: matrix.os != 'macos-14'
+        if: matrix.os != 'macos-latest'
         run: |
           sudo apt-get install -y libaio-dev
+      - name: Cache mysql downloads
+        uses: actions/cache@v4
+        with:
+          path: testing-mysql-server-8/dist
+          key: mysql-downloads-${{ hashFiles('**/repack-mysql-8.sh') }}
       - name: Run Maven install
         run: |
           echo $PATH

--- a/.github/workflows/testing-mysql-server-8.yml
+++ b/.github/workflows/testing-mysql-server-8.yml
@@ -1,4 +1,4 @@
-name: Java Maven Build
+name: Build and Test
 
 on:
   push:
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-14]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 
@@ -24,10 +24,23 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '8'
-          distribution: 'temurin'
+          distribution: 'corretto'
           cache: 'maven'
+      - name: Set up Homebrew
+        if: matrix.os == 'macos-14'
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+      - name: Install GNU binutils
+        if: matrix.os == 'macos-14'
+        run: |
+          brew install binutils
+          brew install patchelf
+          echo /opt/homebrew/opt/binutils/bin >> $GITHUB_PATH
       - name: Install libaio-dev
+        if: matrix.os != 'macos-14'
         run: |
           sudo apt-get install -y libaio-dev
       - name: Run Maven install
-        run: ./mvnw -B --no-transfer-progress clean install -pl testing-mysql-server-8 -am
+        run: |
+          echo $PATH
+          ./mvnw -B --no-transfer-progress clean install -pl testing-mysql-server-8 -am

--- a/testing-mysql-server-8/repack-mysql-8.sh
+++ b/testing-mysql-server-8/repack-mysql-8.sh
@@ -6,7 +6,7 @@ VERSION=8.4.3
 BASEURL="https://dev.mysql.com/get/Downloads/MySQL-8.4"
 
 LINUX_BASE=mysql-$VERSION-linux-glibc2.28-x86_64
-MACOS_BASE=mysql-$VERSION-macos14-x86_64
+MACOS_BASE=mysql-$VERSION-macos14-arm64
 
 TAR=tar
 command -v gtar >/dev/null && TAR=gtar
@@ -29,12 +29,12 @@ then
     exit 100
 fi
 
-PATCHELF=PATCHELF
+PATCHELF=patchelf
 command -v patchelf >/dev/null && PATCHELF=patchelf
 
 set -x
 
-cd $(dirname $0)
+cd "$(dirname $0)"
 
 RESOURCES=target/generated-resources
 
@@ -107,5 +107,5 @@ function pack_linux() {
     rm -rf $PACKDIR
 }
 
-test -e $RESOURCES/mysql-Mac_OS_X-amd64.tar.gz || pack_macos $MACOS_DIST $MACOS_BASE mysql-Mac_OS_X-amd64.tar.gz
+test -e $RESOURCES/mysql-Mac_OS_X-aarch64.tar.gz || pack_macos $MACOS_DIST $MACOS_BASE mysql-Mac_OS_X-aarch64.tar.gz
 test -e $RESOURCES/mysql-Linux-amd64.tar.gz || pack_linux $LINUX_DIST $LINUX_BASE mysql-Linux-amd64.tar.gz


### PR DESCRIPTION
The last mac to be sold with x86_64 architecture is Mac Pro which was finally released with an ARM architecture in 2023. While MacOS may support x86_64 until ~2027, I think we should be safe to swap the x86_64 support to ARM64 in this library. Most developers of Presto are on either running linux or semi-recent (1-4 year old) Macs.